### PR TITLE
Change 'fi' to 'en' in i18n language selection logic

### DIFF
--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -25,7 +25,7 @@ const languageDetector = <LanguageDetectorAsyncModule>{
   detect: async (callback: any) => {
     const savedDataJSON = await getItem(LOCALE);
     const lng = savedDataJSON || null;
-    const selectLanguage = lng || systemLng || 'fi';
+    const selectLanguage = lng || systemLng || 'en';
     callback(selectLanguage);
   },
   cacheUserLanguage: () => {},


### PR DESCRIPTION
Removes references to languages other than English (fi, sv).